### PR TITLE
fix colors_name for solarized-low

### DIFF
--- a/lua/solarized/solarized-low/highlights.lua
+++ b/lua/solarized/solarized-low/highlights.lua
@@ -16,7 +16,7 @@ if fn.exists("syntax_on") then
 	cmd('syntax reset')
 end
 
-g.colors_name = 'solarized-light'
+g.colors_name = 'solarized-low'
 
 local settings = {
 	solarized_visibility = 'normal',


### PR DESCRIPTION
Hopefully fairly self-explanatory, `solarized-low` doesn't work without the change.