### PR TITLE
Less harsh colors and decorations for Lsp diagnostics

### DIFF
--- a/lua/solarized/solarized-flat/highlights.lua
+++ b/lua/solarized/solarized-flat/highlights.lua
@@ -387,7 +387,7 @@ function M.load_syntax(colors)
 	syntax['TSTypeBuiltin'] = syntax['Type']
 	-- syntax['TSEmphasis'] = syntax['']
 
-	syntax['LspDiagnosticsDefaultError'] = {fg=colors.orange,guisp=colors.orange,style='none'}
+	syntax['LspDiagnosticsDefaultError'] = {fg=colors.red,guisp=colors.red,style='none'}
 	syntax['LspDiagnosticsDefaultWarning'] = {fg=colors.yellow,guisp=colors.yellow,style='none'}
 	syntax['LspDiagnosticsDefaultInformation'] = {fg=colors.cyan,guisp=colors.cyan,style='none'}
 	syntax['LspDiagnosticsDefaultHint'] = {fg=colors.green,guisp=colors.green,style='none'}

--- a/lua/solarized/solarized-high/highlights.lua
+++ b/lua/solarized/solarized-high/highlights.lua
@@ -407,7 +407,7 @@ function M.load_syntax(colors)
 	syntax['TSTypeBuiltin'] = syntax['Type']
 	-- syntax['TSEmphasis'] = syntax['']
 
-	syntax['LspDiagnosticsDefaultError'] = {fg=colors.orange,guisp=colors.orange,style='none'}
+	syntax['LspDiagnosticsDefaultError'] = {fg=colors.red,guisp=colors.red,style='none'}
 	syntax['LspDiagnosticsDefaultWarning'] = {fg=colors.yellow,guisp=colors.yellow,style='none'}
 	syntax['LspDiagnosticsDefaultInformation'] = {fg=colors.cyan,guisp=colors.cyan,style='none'}
 	syntax['LspDiagnosticsDefaultHint'] = {fg=colors.green,guisp=colors.green,style='none'}

--- a/lua/solarized/solarized-low/highlights.lua
+++ b/lua/solarized/solarized-low/highlights.lua
@@ -344,7 +344,7 @@ function M.load_syntax(colors)
 	syntax['pandocLineBreak'] = syntax['pandocEscapePair']
 	syntax['pandocMetadataTitle'] = syntax['pandocMetadata']
 
-	syntax['LspDiagnosticsDefaultError'] = {fg=colors.orange,guisp=colors.orange,style='none'}
+	syntax['LspDiagnosticsDefaultError'] = {fg=colors.red,guisp=colors.red,style='none'}
 	syntax['LspDiagnosticsDefaultWarning'] = {fg=colors.yellow,guisp=colors.yellow,style='none'}
 	syntax['LspDiagnosticsDefaultInformation'] = {fg=colors.cyan,guisp=colors.cyan,style='none'}
 	syntax['LspDiagnosticsDefaultHint'] = {fg=colors.green,guisp=colors.green,style='none'}

--- a/lua/solarized/solarized-normal/highlights.lua
+++ b/lua/solarized/solarized-normal/highlights.lua
@@ -388,7 +388,7 @@ function M.load_syntax(colors)
 	syntax['TSTypeBuiltin'] = syntax['Type']
 	-- syntax['TSEmphasis'] = syntax['']
 
-	syntax['LspDiagnosticsDefaultError'] = {fg=colors.orange,guisp=colors.orange,style='none'}
+	syntax['LspDiagnosticsDefaultError'] = {fg=colors.red,guisp=colors.red,style='none'}
 	syntax['LspDiagnosticsDefaultWarning'] = {fg=colors.yellow,guisp=colors.yellow,style='none'}
 	syntax['LspDiagnosticsDefaultInformation'] = {fg=colors.cyan,guisp=colors.cyan,style='none'}
 	syntax['LspDiagnosticsDefaultHint'] = {fg=colors.green,guisp=colors.green,style='none'}


### PR DESCRIPTION
I'm happy with this beautiful theme, but I hope a little tuning is still possible.
I removed underlines from messages. Leaving them only on code targets.
Would you mind that orange is more comfortable than red for errors? )
