### PR TITLE
Make ruby symbols look like strings (closes #19)

### DIFF
--- a/lua/solarized/solarized-flat/highlights.lua
+++ b/lua/solarized/solarized-flat/highlights.lua
@@ -327,7 +327,7 @@ function M.load_syntax(colors)
 	syntax['gitcommitSelectedArrow'] = syntax['gitcommitSelectedFile']
 	syntax['gitcommitUnmergedArrow'] = syntax['gitcommitUnmergedFile']
 	syntax['jsFuncCall'] = syntax['Function']
-	syntax['rubySymbol'] = syntax['Type']
+	syntax['rubySymbol'] = syntax['String']
 	syntax['hsImportParams'] = syntax['Delimiter']
 	syntax['hsDelimTypeExport'] = syntax['Delimiter']
 	syntax['hsModuleStartLabel'] = syntax['hsStructure']

--- a/lua/solarized/solarized-high/highlights.lua
+++ b/lua/solarized/solarized-high/highlights.lua
@@ -347,7 +347,7 @@ function M.load_syntax(colors)
 	syntax['gitcommitSelectedArrow'] = syntax['gitcommitSelectedFile']
 	syntax['gitcommitUnmergedArrow'] = syntax['gitcommitUnmergedFile']
 	syntax['jsFuncCall'] = syntax['Function']
-	syntax['rubySymbol'] = syntax['Type']
+	syntax['rubySymbol'] = syntax['String']
 	syntax['hsImportParams'] = syntax['Delimiter']
 	syntax['hsDelimTypeExport'] = syntax['Delimiter']
 	syntax['hsModuleStartLabel'] = syntax['hsStructure']

--- a/lua/solarized/solarized-low/highlights.lua
+++ b/lua/solarized/solarized-low/highlights.lua
@@ -330,7 +330,7 @@ function M.load_syntax(colors)
 	syntax['gitcommitSelectedArrow'] = syntax['gitcommitSelectedFile']
 	syntax['gitcommitUnmergedArrow'] = syntax['gitcommitUnmergedFile']
 	syntax['jsFuncCall'] = syntax['Function']
-	syntax['rubySymbol'] = syntax['Type']
+	syntax['rubySymbol'] = syntax['String']
 	syntax['hsImportParams'] = syntax['Delimiter']
 	syntax['hsDelimTypeExport'] = syntax['Delimiter']
 	syntax['hsModuleStartLabel'] = syntax['hsStructure']

--- a/lua/solarized/solarized-normal/highlights.lua
+++ b/lua/solarized/solarized-normal/highlights.lua
@@ -328,7 +328,7 @@ function M.load_syntax(colors)
 	syntax['gitcommitSelectedArrow'] = syntax['gitcommitSelectedFile']
 	syntax['gitcommitUnmergedArrow'] = syntax['gitcommitUnmergedFile']
 	syntax['jsFuncCall'] = syntax['Function']
-	syntax['rubySymbol'] = syntax['Type']
+	syntax['rubySymbol'] = syntax['String']
 	syntax['hsImportParams'] = syntax['Delimiter']
 	syntax['hsDelimTypeExport'] = syntax['Delimiter']
 	syntax['hsModuleStartLabel'] = syntax['hsStructure']


### PR DESCRIPTION
Ruby symbols are very much like strings. At the moment they're looking like types, as reported in #19. I took a closer look and this was actually pretty easy to change!