### PR TITLE
corrected diagnostic highlights

### DIFF
--- a/lua/solarized/solarized-flat/highlights.lua
+++ b/lua/solarized/solarized-flat/highlights.lua
@@ -387,20 +387,16 @@ function M.load_syntax(colors)
 	syntax['TSTypeBuiltin'] = syntax['Type']
 	-- syntax['TSEmphasis'] = syntax['']
 
-	syntax['LspDiagnosticsDefaultError'] = {fg=colors.red,guisp=colors.red,style='none'}
-	syntax['LspDiagnosticsDefaultWarning'] = {fg=colors.yellow,guisp=colors.yellow,style='none'}
-	syntax['LspDiagnosticsDefaultInformation'] = {fg=colors.cyan,guisp=colors.cyan,style='none'}
-	syntax['LspDiagnosticsDefaultHint'] = {fg=colors.green,guisp=colors.green,style='none'}
-	syntax['LspDiagnosticsUnderlineError'] = {fg=colors.none,guisp=colors.none,style='underline'}
-	syntax['LspDiagnosticsUnderlineWarning'] = {fg=colors.none,guisp=colors.none,style='underline'}
-	syntax['LspDiagnosticsUnderlineInformation'] = {fg=colors.none,guisp=colors.none,style='underline'}
-	syntax['LspDiagnosticsUnderlineHint'] = {fg=colors.none,guisp=colors.none,style='underline'}
+	syntax['DiagnosticError'] = {fg=colors.red,guisp=colors.red,style='none'}
+	syntax['DiagnosticWarning'] = {fg=colors.yellow,guisp=colors.yellow,style='none'}
+	syntax['DiagnosticInformation'] = {fg=colors.cyan,guisp=colors.cyan,style='none'}
+	syntax['DiagnosticHint'] = {fg=colors.green,guisp=colors.green,style='none'}
+	syntax['DiagnosticUnderlineError'] = {fg=colors.none,guisp=colors.red,style='underline'}
+	syntax['DiagnosticUnderlineWarning'] = {fg=colors.none,guisp=colors.yellow,style='underline'}
+	syntax['DiagnosticUnderlineInformation'] = {fg=colors.none,guisp=colors.cyan,style='underline'}
+	syntax['DiagnosticUnderlineHint'] = {fg=colors.none,guisp=colors.green,style='underline'}
 
 	syntax['LspSagaFinderSelection'] = syntax['Search']
-	syntax['DiagnosticError'] = syntax['LspDiagnosticsDefaultError']
-	syntax['DiagnosticWarning'] = syntax['LspDiagnosticsDefaultWarning']
-	syntax['DiagnosticInformation'] = syntax['LspDiagnosticsDefaultInformation']
-	syntax['DiagnosticHint'] = syntax['LspDiagnosticsDefaultHint']
 	syntax['TargetWord'] = syntax['Title']
 
 	syntax['GitSignsAdd'] = syntax['DiffAdd']

--- a/lua/solarized/solarized-high/highlights.lua
+++ b/lua/solarized/solarized-high/highlights.lua
@@ -407,20 +407,16 @@ function M.load_syntax(colors)
 	syntax['TSTypeBuiltin'] = syntax['Type']
 	-- syntax['TSEmphasis'] = syntax['']
 
-	syntax['LspDiagnosticsDefaultError'] = {fg=colors.red,guisp=colors.red,style='none'}
-	syntax['LspDiagnosticsDefaultWarning'] = {fg=colors.yellow,guisp=colors.yellow,style='none'}
-	syntax['LspDiagnosticsDefaultInformation'] = {fg=colors.cyan,guisp=colors.cyan,style='none'}
-	syntax['LspDiagnosticsDefaultHint'] = {fg=colors.green,guisp=colors.green,style='none'}
-	syntax['LspDiagnosticsUnderlineError'] = {fg=colors.none,guisp=colors.none,style='underline'}
-	syntax['LspDiagnosticsUnderlineWarning'] = {fg=colors.none,guisp=colors.none,style='underline'}
-	syntax['LspDiagnosticsUnderlineInformation'] = {fg=colors.none,guisp=colors.none,style='underline'}
-	syntax['LspDiagnosticsUnderlineHint'] = {fg=colors.none,guisp=colors.none,style='underline'}
+	syntax['DiagnosticError'] = {fg=colors.red,guisp=colors.red,style='none'}
+	syntax['DiagnosticWarning'] = {fg=colors.yellow,guisp=colors.yellow,style='none'}
+	syntax['DiagnosticInformation'] = {fg=colors.cyan,guisp=colors.cyan,style='none'}
+	syntax['DiagnosticHint'] = {fg=colors.green,guisp=colors.green,style='none'}
+	syntax['DiagnosticUnderlineError'] = {fg=colors.none,guisp=colors.red,style='underline'}
+	syntax['DiagnosticUnderlineWarning'] = {fg=colors.none,guisp=colors.yellow,style='underline'}
+	syntax['DiagnosticUnderlineInformation'] = {fg=colors.none,guisp=colors.cyan,style='underline'}
+	syntax['DiagnosticUnderlineHint'] = {fg=colors.none,guisp=colors.green,style='underline'}
 
 	syntax['LspSagaFinderSelection'] = syntax['Search']
-	syntax['DiagnosticError'] = syntax['LspDiagnosticsDefaultError']
-	syntax['DiagnosticWarning'] = syntax['LspDiagnosticsDefaultWarning']
-	syntax['DiagnosticInformation'] = syntax['LspDiagnosticsDefaultInformation']
-	syntax['DiagnosticHint'] = syntax['LspDiagnosticsDefaultHint']
 	syntax['TargetWord'] = syntax['Title']
 
 	syntax['GitSignsAdd'] = syntax['DiffAdd']

--- a/lua/solarized/solarized-low/highlights.lua
+++ b/lua/solarized/solarized-low/highlights.lua
@@ -344,20 +344,16 @@ function M.load_syntax(colors)
 	syntax['pandocLineBreak'] = syntax['pandocEscapePair']
 	syntax['pandocMetadataTitle'] = syntax['pandocMetadata']
 
-	syntax['LspDiagnosticsDefaultError'] = {fg=colors.red,guisp=colors.red,style='none'}
-	syntax['LspDiagnosticsDefaultWarning'] = {fg=colors.yellow,guisp=colors.yellow,style='none'}
-	syntax['LspDiagnosticsDefaultInformation'] = {fg=colors.cyan,guisp=colors.cyan,style='none'}
-	syntax['LspDiagnosticsDefaultHint'] = {fg=colors.green,guisp=colors.green,style='none'}
-	syntax['LspDiagnosticsUnderlineError'] = {fg=colors.none,guisp=colors.none,style='underline'}
-	syntax['LspDiagnosticsUnderlineWarning'] = {fg=colors.none,guisp=colors.none,style='underline'}
-	syntax['LspDiagnosticsUnderlineInformation'] = {fg=colors.none,guisp=colors.none,style='underline'}
-	syntax['LspDiagnosticsUnderlineHint'] = {fg=colors.none,guisp=colors.none,style='underline'}
+	syntax['DiagnosticError'] = {fg=colors.red,guisp=colors.red,style='none'}
+	syntax['DiagnosticWarning'] = {fg=colors.yellow,guisp=colors.yellow,style='none'}
+	syntax['DiagnosticInformation'] = {fg=colors.cyan,guisp=colors.cyan,style='none'}
+	syntax['DiagnosticHint'] = {fg=colors.green,guisp=colors.green,style='none'}
+	syntax['DiagnosticUnderlineError'] = {fg=colors.none,guisp=colors.red,style='underline'}
+	syntax['DiagnosticUnderlineWarning'] = {fg=colors.none,guisp=colors.yellow,style='underline'}
+	syntax['DiagnosticUnderlineInformation'] = {fg=colors.none,guisp=colors.cyan,style='underline'}
+	syntax['DiagnosticUnderlineHint'] = {fg=colors.none,guisp=colors.green,style='underline'}
 
 	syntax['LspSagaFinderSelection'] = syntax['Search']
-	syntax['DiagnosticError'] = syntax['LspDiagnosticsDefaultError']
-	syntax['DiagnosticWarning'] = syntax['LspDiagnosticsDefaultWarning']
-	syntax['DiagnosticInformation'] = syntax['LspDiagnosticsDefaultInformation']
-	syntax['DiagnosticHint'] = syntax['LspDiagnosticsDefaultHint']
 	syntax['TargetWord'] = syntax['Title']
 
 	syntax['GitSignsAdd'] = syntax['DiffAdd']

--- a/lua/solarized/solarized-normal/highlights.lua
+++ b/lua/solarized/solarized-normal/highlights.lua
@@ -388,21 +388,17 @@ function M.load_syntax(colors)
 	syntax['TSTypeBuiltin'] = syntax['Type']
 	-- syntax['TSEmphasis'] = syntax['']
 
-	syntax['LspDiagnosticsDefaultError'] = {fg=colors.red,guisp=colors.red,style='none'}
-	syntax['LspDiagnosticsDefaultWarning'] = {fg=colors.yellow,guisp=colors.yellow,style='none'}
-	syntax['LspDiagnosticsDefaultInformation'] = {fg=colors.cyan,guisp=colors.cyan,style='none'}
-	syntax['LspDiagnosticsDefaultHint'] = {fg=colors.green,guisp=colors.green,style='none'}
-	syntax['LspDiagnosticsUnderlineError'] = {fg=colors.none,guisp=colors.none,style='underline'}
-	syntax['LspDiagnosticsUnderlineWarning'] = {fg=colors.none,guisp=colors.none,style='underline'}
-	syntax['LspDiagnosticsUnderlineInformation'] = {fg=colors.none,guisp=colors.none,style='underline'}
-	syntax['LspDiagnosticsUnderlineHint'] = {fg=colors.none,guisp=colors.none,style='underline'}
+	syntax['DiagnosticError'] = {fg=colors.red,guisp=colors.red,style='none'}
+	syntax['DiagnosticWarning'] = {fg=colors.yellow,guisp=colors.yellow,style='none'}
+	syntax['DiagnosticInformation'] = {fg=colors.cyan,guisp=colors.cyan,style='none'}
+	syntax['DiagnosticHint'] = {fg=colors.green,guisp=colors.green,style='none'}
+	syntax['DiagnosticUnderlineError'] = {fg=colors.none,guisp=colors.red,style='underline'}
+	syntax['DiagnosticUnderlineWarning'] = {fg=colors.none,guisp=colors.yellow,style='underline'}
+	syntax['DiagnosticUnderlineInformation'] = {fg=colors.none,guisp=colors.cyan,style='underline'}
+	syntax['DiagnosticUnderlineHint'] = {fg=colors.none,guisp=colors.green,style='underline'}
 
 	-- Lspsaga
 	syntax['LspSagaFinderSelection'] = syntax['Search']
-	syntax['DiagnosticError'] = syntax['LspDiagnosticsDefaultError']
-	syntax['DiagnosticWarning'] = syntax['LspDiagnosticsDefaultWarning']
-	syntax['DiagnosticInformation'] = syntax['LspDiagnosticsDefaultInformation']
-	syntax['DiagnosticHint'] = syntax['LspDiagnosticsDefaultHint']
 	syntax['TargetWord'] = syntax['Title']
 
 	syntax['GitSignsAdd'] = syntax['DiffAdd']


### PR DESCRIPTION
The names of the diagnostic highlight groups have changed with the move from vim.lsp.diagnostic to vim.diagnostic