### PR TITLE
Map `Delimiter` to `Normal` instead of `Special`

### DIFF
--- a/lua/solarized/solarized-flat/highlights.lua
+++ b/lua/solarized/solarized-flat/highlights.lua
@@ -286,7 +286,7 @@ function M.load_syntax(colors)
 	syntax['Conditional'] = syntax['Statement']
 	syntax['Debug'] = syntax['Special']
 	syntax['Define'] = syntax['PreProc']
-	syntax['Delimiter'] = syntax['Special']
+	syntax['Delimiter'] = syntax['Normal']
 	syntax['Exception'] = syntax['Statement']
 	syntax['Float'] = syntax['Constant']
 	syntax['FloatBorder'] = syntax['VertSplit']

--- a/lua/solarized/solarized-high/highlights.lua
+++ b/lua/solarized/solarized-high/highlights.lua
@@ -307,7 +307,7 @@ function M.load_syntax(colors)
 	syntax['Conditional'] = syntax['Statement']
 	syntax['Debug'] = syntax['Special']
 	syntax['Define'] = syntax['PreProc']
-	syntax['Delimiter'] = syntax['Special']
+	syntax['Delimiter'] = syntax['Normal']
 	syntax['Exception'] = syntax['Statement']
 	syntax['Float'] = syntax['Constant']
 	syntax['FloatBorder'] = syntax['VertSplit']

--- a/lua/solarized/solarized-low/highlights.lua
+++ b/lua/solarized/solarized-low/highlights.lua
@@ -290,7 +290,7 @@ function M.load_syntax(colors)
 	syntax['Conditional'] = syntax['Statement']
 	syntax['Debug'] = syntax['Special']
 	syntax['Define'] = syntax['PreProc']
-	syntax['Delimiter'] = syntax['Special']
+	syntax['Delimiter'] = syntax['Normal']
 	syntax['Exception'] = syntax['Statement']
 	syntax['Float'] = syntax['Constant']
 	syntax['FloatBorder'] = syntax['VertSplit']

--- a/lua/solarized/solarized-normal/highlights.lua
+++ b/lua/solarized/solarized-normal/highlights.lua
@@ -289,7 +289,7 @@ function M.load_syntax(colors)
 	syntax['Conditional'] = syntax['Statement']
 	syntax['Debug'] = syntax['Special']
 	syntax['Define'] = syntax['PreProc']
-	syntax['Delimiter'] = syntax['Special']
+	syntax['Delimiter'] = syntax['Normal']
 	syntax['Exception'] = syntax['Statement']
 	syntax['Float'] = syntax['Constant']
 	syntax['Function'] = syntax['Identifier']


### PR DESCRIPTION
As mentioned in #33 the `Delimiter` highlight group is currently mapped to `Special`, resulting in dots, parentheses, etc. to be orange.  This PR maps it to `Normal` instead, so they don't stand out so much.  Here is an before/after screenshot:

![solarized](https://user-images.githubusercontent.com/9333121/149921674-12bd42a1-341d-4c51-9b8c-1f6df26074f4.png)


I see that this is a matter of taste, though, so I if you don't agree with the change, I'm completely fine with it!

How I tested: I had this change applied locally for a while now and at least for the Python and C++ code I'm working with, it looks good to me.  I normally only use the normal "solarized" scheme, though, so I quickly checked the -flat/-high/-low variants and the seemed good as well.

Resolves #33