### PR TITLE
Add LspReference{Text,Read,Write} highlight groups

### DIFF
--- a/lua/solarized/solarized-flat/highlights.lua
+++ b/lua/solarized/solarized-flat/highlights.lua
@@ -396,6 +396,10 @@ function M.load_syntax(colors)
 	syntax['DiagnosticUnderlineInformation'] = {fg=colors.none,guisp=colors.cyan,style='underline'}
 	syntax['DiagnosticUnderlineHint'] = {fg=colors.none,guisp=colors.green,style='underline'}
 
+	syntax['LspReferenceRead'] = {fg=colors.none,style='underline'}
+	syntax['LspReferenceText'] = syntax['LspReferenceRead']
+	syntax['LspReferenceWrite'] = {fg=colors.none,style='underline,bold'}
+
 	syntax['LspSagaFinderSelection'] = syntax['Search']
 	syntax['TargetWord'] = syntax['Title']
 

--- a/lua/solarized/solarized-high/highlights.lua
+++ b/lua/solarized/solarized-high/highlights.lua
@@ -416,6 +416,10 @@ function M.load_syntax(colors)
 	syntax['DiagnosticUnderlineInformation'] = {fg=colors.none,guisp=colors.cyan,style='underline'}
 	syntax['DiagnosticUnderlineHint'] = {fg=colors.none,guisp=colors.green,style='underline'}
 
+	syntax['LspReferenceRead'] = {fg=colors.none,style='underline'}
+	syntax['LspReferenceText'] = syntax['LspReferenceRead']
+	syntax['LspReferenceWrite'] = {fg=colors.none,style='underline,bold'}
+
 	syntax['LspSagaFinderSelection'] = syntax['Search']
 	syntax['TargetWord'] = syntax['Title']
 

--- a/lua/solarized/solarized-low/highlights.lua
+++ b/lua/solarized/solarized-low/highlights.lua
@@ -353,6 +353,10 @@ function M.load_syntax(colors)
 	syntax['DiagnosticUnderlineInformation'] = {fg=colors.none,guisp=colors.cyan,style='underline'}
 	syntax['DiagnosticUnderlineHint'] = {fg=colors.none,guisp=colors.green,style='underline'}
 
+	syntax['LspReferenceRead'] = {fg=colors.none,style='underline'}
+	syntax['LspReferenceText'] = syntax['LspReferenceRead']
+	syntax['LspReferenceWrite'] = {fg=colors.none,style='underline,bold'}
+
 	syntax['LspSagaFinderSelection'] = syntax['Search']
 	syntax['TargetWord'] = syntax['Title']
 

--- a/lua/solarized/solarized-normal/highlights.lua
+++ b/lua/solarized/solarized-normal/highlights.lua
@@ -397,6 +397,10 @@ function M.load_syntax(colors)
 	syntax['DiagnosticUnderlineInformation'] = {fg=colors.none,guisp=colors.cyan,style='underline'}
 	syntax['DiagnosticUnderlineHint'] = {fg=colors.none,guisp=colors.green,style='underline'}
 
+	syntax['LspReferenceRead'] = {fg=colors.none,style='underline'}
+	syntax['LspReferenceText'] = syntax['LspReferenceRead']
+	syntax['LspReferenceWrite'] = {fg=colors.none,style='underline,bold'}
+
 	-- Lspsaga
 	syntax['LspSagaFinderSelection'] = syntax['Search']
 	syntax['TargetWord'] = syntax['Title']


### PR DESCRIPTION
Those groups are used by `vim.lsp.buf.document_highlight()` to highlight references of the object under the cursor.
They don't have any highlighting be default, so I thought it makes sense to add them to the colorscheme.

I colours are copied from the `Visual` group which in my opinion results in a notable but not too distracting highlighting:

![all](https://user-images.githubusercontent.com/9333121/150494960-7ba0ee77-3e1a-4dcb-883f-39af9aca21a4.jpg)

I only tested this with Python, though, so not sure how it would look like for other languages.
