### PR TITLE
Add support for SmiteshP/nvim-navic #50

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ This is the low contrast option.
    - [x] FZF  
    - [x] lualine  
    - [x] lspsaga
+   - [x] nvim-navic
 
 # NOTE
 - Thanks for lifepillar's vim-solarized8 for providing most of the highlights and color codes for this scheme.

--- a/lua/solarized/solarized-flat/highlights.lua
+++ b/lua/solarized/solarized-flat/highlights.lua
@@ -471,8 +471,9 @@ function M.load_syntax(colors)
 	syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
 	syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
 	syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
-	syntax['NavicText'] = { fg = colors.gray, bg = colors.none}
-	syntax['NavicSeparator'] = {fg=colors.base01,style=utils.italics()}
+	syntax['NavicText'] = syntax['Comment']
+	syntax['NavicSeparator'] = syntax['Comment']
+
 
 
 	for group, highlights in pairs(syntax) do

--- a/lua/solarized/solarized-flat/highlights.lua
+++ b/lua/solarized/solarized-flat/highlights.lua
@@ -471,7 +471,7 @@ function M.load_syntax(colors)
 	syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
 	syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
 	syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
-	syntax['NavicText'] = syntax['Comment']
+	syntax['NavicText'] = syntax['LineNr']
 	syntax['NavicSeparator'] = syntax['Comment']
 
 

--- a/lua/solarized/solarized-flat/highlights.lua
+++ b/lua/solarized/solarized-flat/highlights.lua
@@ -444,6 +444,37 @@ function M.load_syntax(colors)
 	syntax['CmpItemKindOperator' ] = {fg=colors.base0, bg=colors.none }
 	syntax['CmpItemKindSnippet' ] = {fg=colors.orange, bg=colors.none }
 
+  syntax['NavicIconsFile'] = syntax['CmpItemKindFile']
+  syntax['NavicIconsModule'] = syntax['CmpItemKindModule']
+  syntax['NavicIconsNamespace'] = syntax['CmpItemKindModule']
+  syntax['NavicIconsPackage'] = syntax['CmpItemKindModule']
+  syntax['NavicIconsClass'] = syntax['CmpItemKindClass']
+  syntax['NavicIconsMethod'] = syntax['CmpItemKindMethod']
+  syntax['NavicIconsProperty'] = syntax['CmpItemKindProperty']
+  syntax['NavicIconsField'] = syntax['CmpItemKindField']
+  syntax['NavicIconsConstructor'] = syntax['CmpItemKindConstructor']
+  syntax['NavicIconsEnum'] = syntax['CmpItemKindEnum']
+  syntax['NavicIconsInterface'] = syntax['CmpItemKindInterface'
+  syntax['NavicIconsFunction'] = syntax['CmpItemKindFunction'
+  syntax['NavicIconsVariable'] = syntax ['CmpItemKindVariable']
+  syntax['NavicIconsConstant'] = syntax['CmpItemKindConstant']
+  syntax['NavicIconsString'] = syntax['String']
+  syntax['NavicIconsNumber'] = syntax['Number']
+  syntax['NavicIconsBoolean'] = syntax['Boolean']
+  syntax['NavicIconsArray'] = syntax['CmpItemKindClass']
+  syntax['NavicIconsObject'] = syntax['CmpItemKindClass']
+  syntax['NavicIconsKey'] = syntax['CmpItemKindKeyword']
+  syntax['NavicIconsKeyword'] = syntax['CmpItemKindKeyword']
+  syntax['NavicIconsNull'] =  {fg=colors.blue, bg=colors.none }
+  syntax['NavicIconsEnumMember'] = syntax['CmpItemKindEnumMember']
+  syntax['NavicIconsStruct'] = syntax['CmpItemKindStruct']
+  syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
+  syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
+  syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
+  syntax['NavicText'] = { fg = colors.gray, bg = colors.none}
+  syntax['NavicSeparator'] = {fg=colors.base01,style=utils.italics()}
+
+
 	for group, highlights in pairs(syntax) do
 		utils.highlighter(group, highlights)
 	end

--- a/lua/solarized/solarized-flat/highlights.lua
+++ b/lua/solarized/solarized-flat/highlights.lua
@@ -444,35 +444,35 @@ function M.load_syntax(colors)
 	syntax['CmpItemKindOperator' ] = {fg=colors.base0, bg=colors.none }
 	syntax['CmpItemKindSnippet' ] = {fg=colors.orange, bg=colors.none }
 
-  syntax['NavicIconsFile'] = syntax['CmpItemKindFile']
-  syntax['NavicIconsModule'] = syntax['CmpItemKindModule']
-  syntax['NavicIconsNamespace'] = syntax['CmpItemKindModule']
-  syntax['NavicIconsPackage'] = syntax['CmpItemKindModule']
-  syntax['NavicIconsClass'] = syntax['CmpItemKindClass']
-  syntax['NavicIconsMethod'] = syntax['CmpItemKindMethod']
-  syntax['NavicIconsProperty'] = syntax['CmpItemKindProperty']
-  syntax['NavicIconsField'] = syntax['CmpItemKindField']
-  syntax['NavicIconsConstructor'] = syntax['CmpItemKindConstructor']
-  syntax['NavicIconsEnum'] = syntax['CmpItemKindEnum']
-  syntax['NavicIconsInterface'] = syntax['CmpItemKindInterface'
-  syntax['NavicIconsFunction'] = syntax['CmpItemKindFunction'
-  syntax['NavicIconsVariable'] = syntax ['CmpItemKindVariable']
-  syntax['NavicIconsConstant'] = syntax['CmpItemKindConstant']
-  syntax['NavicIconsString'] = syntax['String']
-  syntax['NavicIconsNumber'] = syntax['Number']
-  syntax['NavicIconsBoolean'] = syntax['Boolean']
-  syntax['NavicIconsArray'] = syntax['CmpItemKindClass']
-  syntax['NavicIconsObject'] = syntax['CmpItemKindClass']
-  syntax['NavicIconsKey'] = syntax['CmpItemKindKeyword']
-  syntax['NavicIconsKeyword'] = syntax['CmpItemKindKeyword']
-  syntax['NavicIconsNull'] =  {fg=colors.blue, bg=colors.none }
-  syntax['NavicIconsEnumMember'] = syntax['CmpItemKindEnumMember']
-  syntax['NavicIconsStruct'] = syntax['CmpItemKindStruct']
-  syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
-  syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
-  syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
-  syntax['NavicText'] = { fg = colors.gray, bg = colors.none}
-  syntax['NavicSeparator'] = {fg=colors.base01,style=utils.italics()}
+	syntax['NavicIconsFile'] = syntax['CmpItemKindFile']
+	syntax['NavicIconsModule'] = syntax['CmpItemKindModule']
+	syntax['NavicIconsNamespace'] = syntax['CmpItemKindModule']
+	syntax['NavicIconsPackage'] = syntax['CmpItemKindModule']
+	syntax['NavicIconsClass'] = syntax['CmpItemKindClass']
+	syntax['NavicIconsMethod'] = syntax['CmpItemKindMethod']
+	syntax['NavicIconsProperty'] = syntax['CmpItemKindProperty']
+	syntax['NavicIconsField'] = syntax['CmpItemKindField']
+	syntax['NavicIconsConstructor'] = syntax['CmpItemKindConstructor']
+	syntax['NavicIconsEnum'] = syntax['CmpItemKindEnum']
+	syntax['NavicIconsInterface'] = syntax['CmpItemKindInterface']
+	syntax['NavicIconsFunction'] = syntax['CmpItemKindFunction']
+	syntax['NavicIconsVariable'] = syntax ['CmpItemKindVariable']
+	syntax['NavicIconsConstant'] = syntax['CmpItemKindConstant']
+	syntax['NavicIconsString'] = syntax['String']
+	syntax['NavicIconsNumber'] = syntax['Number']
+	syntax['NavicIconsBoolean'] = syntax['Boolean']
+	syntax['NavicIconsArray'] = syntax['CmpItemKindClass']
+	syntax['NavicIconsObject'] = syntax['CmpItemKindClass']
+	syntax['NavicIconsKey'] = syntax['CmpItemKindKeyword']
+	syntax['NavicIconsKeyword'] = syntax['CmpItemKindKeyword']
+	syntax['NavicIconsNull'] =  {fg=colors.blue, bg=colors.none }
+	syntax['NavicIconsEnumMember'] = syntax['CmpItemKindEnumMember']
+	syntax['NavicIconsStruct'] = syntax['CmpItemKindStruct']
+	syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
+	syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
+	syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
+	syntax['NavicText'] = { fg = colors.gray, bg = colors.none}
+	syntax['NavicSeparator'] = {fg=colors.base01,style=utils.italics()}
 
 
 	for group, highlights in pairs(syntax) do

--- a/lua/solarized/solarized-high/highlights.lua
+++ b/lua/solarized/solarized-high/highlights.lua
@@ -497,8 +497,9 @@ function M.load_syntax(colors)
 	syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
 	syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
 	syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
-	syntax['NavicText'] = { fg = colors.gray, bg = colors.none}
-	syntax['NavicSeparator'] = {fg=colors.base00,style=utils.italics()}
+	syntax['NavicText'] = syntax['Comment']
+	syntax['NavicSeparator'] = syntax['Comment']
+
 
 	for group, highlights in pairs(syntax) do
 		utils.highlighter(group, highlights)

--- a/lua/solarized/solarized-high/highlights.lua
+++ b/lua/solarized/solarized-high/highlights.lua
@@ -497,7 +497,7 @@ function M.load_syntax(colors)
 	syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
 	syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
 	syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
-	syntax['NavicText'] = syntax['Comment']
+	syntax['NavicText'] = syntax['LineNr']
 	syntax['NavicSeparator'] = syntax['Comment']
 
 

--- a/lua/solarized/solarized-high/highlights.lua
+++ b/lua/solarized/solarized-high/highlights.lua
@@ -470,6 +470,36 @@ function M.load_syntax(colors)
 	syntax['CmpItemKindOperator' ] = {fg=colors.base2, bg=colors.none }
 	syntax['CmpItemKindSnippet' ] = {fg=colors.orange, bg=colors.none }
 
+  syntax['NavicIconsFile'] = syntax['CmpItemKindFile']
+  syntax['NavicIconsModule'] = syntax['CmpItemKindModule']
+  syntax['NavicIconsNamespace'] = syntax['CmpItemKindModule']
+  syntax['NavicIconsPackage'] = syntax['CmpItemKindModule']
+  syntax['NavicIconsClass'] = syntax['CmpItemKindClass']
+  syntax['NavicIconsMethod'] = syntax['CmpItemKindMethod']
+  syntax['NavicIconsProperty'] = syntax['CmpItemKindProperty']
+  syntax['NavicIconsField'] = syntax['CmpItemKindField']
+  syntax['NavicIconsConstructor'] = syntax['CmpItemKindConstructor']
+  syntax['NavicIconsEnum'] = syntax['CmpItemKindEnum']
+  syntax['NavicIconsInterface'] = syntax['CmpItemKindInterface'
+  syntax['NavicIconsFunction'] = syntax['CmpItemKindFunction'
+  syntax['NavicIconsVariable'] = syntax ['CmpItemKindVariable']
+  syntax['NavicIconsConstant'] = syntax['CmpItemKindConstant']
+  syntax['NavicIconsString'] = syntax['String']
+  syntax['NavicIconsNumber'] = syntax['Number']
+  syntax['NavicIconsBoolean'] = syntax['Boolean']
+  syntax['NavicIconsArray'] = syntax['CmpItemKindClass']
+  syntax['NavicIconsObject'] = syntax['CmpItemKindClass']
+  syntax['NavicIconsKey'] = syntax['CmpItemKindKeyword']
+  syntax['NavicIconsKeyword'] = syntax['CmpItemKindKeyword']
+  syntax['NavicIconsNull'] =  {fg=colors.blue, bg=colors.none }
+  syntax['NavicIconsEnumMember'] = syntax['CmpItemKindEnumMember']
+  syntax['NavicIconsStruct'] = syntax['CmpItemKindStruct']
+  syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
+  syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
+  syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
+  syntax['NavicText'] = { fg = colors.gray, bg = colors.none}
+  syntax['NavicSeparator'] = {fg=colors.base00,style=utils.italics()}
+
 	for group, highlights in pairs(syntax) do
 		utils.highlighter(group, highlights)
 	end

--- a/lua/solarized/solarized-high/highlights.lua
+++ b/lua/solarized/solarized-high/highlights.lua
@@ -470,35 +470,35 @@ function M.load_syntax(colors)
 	syntax['CmpItemKindOperator' ] = {fg=colors.base2, bg=colors.none }
 	syntax['CmpItemKindSnippet' ] = {fg=colors.orange, bg=colors.none }
 
-  syntax['NavicIconsFile'] = syntax['CmpItemKindFile']
-  syntax['NavicIconsModule'] = syntax['CmpItemKindModule']
-  syntax['NavicIconsNamespace'] = syntax['CmpItemKindModule']
-  syntax['NavicIconsPackage'] = syntax['CmpItemKindModule']
-  syntax['NavicIconsClass'] = syntax['CmpItemKindClass']
-  syntax['NavicIconsMethod'] = syntax['CmpItemKindMethod']
-  syntax['NavicIconsProperty'] = syntax['CmpItemKindProperty']
-  syntax['NavicIconsField'] = syntax['CmpItemKindField']
-  syntax['NavicIconsConstructor'] = syntax['CmpItemKindConstructor']
-  syntax['NavicIconsEnum'] = syntax['CmpItemKindEnum']
-  syntax['NavicIconsInterface'] = syntax['CmpItemKindInterface'
-  syntax['NavicIconsFunction'] = syntax['CmpItemKindFunction'
-  syntax['NavicIconsVariable'] = syntax ['CmpItemKindVariable']
-  syntax['NavicIconsConstant'] = syntax['CmpItemKindConstant']
-  syntax['NavicIconsString'] = syntax['String']
-  syntax['NavicIconsNumber'] = syntax['Number']
-  syntax['NavicIconsBoolean'] = syntax['Boolean']
-  syntax['NavicIconsArray'] = syntax['CmpItemKindClass']
-  syntax['NavicIconsObject'] = syntax['CmpItemKindClass']
-  syntax['NavicIconsKey'] = syntax['CmpItemKindKeyword']
-  syntax['NavicIconsKeyword'] = syntax['CmpItemKindKeyword']
-  syntax['NavicIconsNull'] =  {fg=colors.blue, bg=colors.none }
-  syntax['NavicIconsEnumMember'] = syntax['CmpItemKindEnumMember']
-  syntax['NavicIconsStruct'] = syntax['CmpItemKindStruct']
-  syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
-  syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
-  syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
-  syntax['NavicText'] = { fg = colors.gray, bg = colors.none}
-  syntax['NavicSeparator'] = {fg=colors.base00,style=utils.italics()}
+	syntax['NavicIconsFile'] = syntax['CmpItemKindFile']
+	syntax['NavicIconsModule'] = syntax['CmpItemKindModule']
+	syntax['NavicIconsNamespace'] = syntax['CmpItemKindModule']
+	syntax['NavicIconsPackage'] = syntax['CmpItemKindModule']
+	syntax['NavicIconsClass'] = syntax['CmpItemKindClass']
+	syntax['NavicIconsMethod'] = syntax['CmpItemKindMethod']
+	syntax['NavicIconsProperty'] = syntax['CmpItemKindProperty']
+	syntax['NavicIconsField'] = syntax['CmpItemKindField']
+	syntax['NavicIconsConstructor'] = syntax['CmpItemKindConstructor']
+	syntax['NavicIconsEnum'] = syntax['CmpItemKindEnum']
+	syntax['NavicIconsInterface'] = syntax['CmpItemKindInterface']
+	syntax['NavicIconsFunction'] = syntax['CmpItemKindFunction']
+	syntax['NavicIconsVariable'] = syntax ['CmpItemKindVariable']
+	syntax['NavicIconsConstant'] = syntax['CmpItemKindConstant']
+	syntax['NavicIconsString'] = syntax['String']
+	syntax['NavicIconsNumber'] = syntax['Number']
+	syntax['NavicIconsBoolean'] = syntax['Boolean']
+	syntax['NavicIconsArray'] = syntax['CmpItemKindClass']
+	syntax['NavicIconsObject'] = syntax['CmpItemKindClass']
+	syntax['NavicIconsKey'] = syntax['CmpItemKindKeyword']
+	syntax['NavicIconsKeyword'] = syntax['CmpItemKindKeyword']
+	syntax['NavicIconsNull'] =  {fg=colors.blue, bg=colors.none }
+	syntax['NavicIconsEnumMember'] = syntax['CmpItemKindEnumMember']
+	syntax['NavicIconsStruct'] = syntax['CmpItemKindStruct']
+	syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
+	syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
+	syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
+	syntax['NavicText'] = { fg = colors.gray, bg = colors.none}
+	syntax['NavicSeparator'] = {fg=colors.base00,style=utils.italics()}
 
 	for group, highlights in pairs(syntax) do
 		utils.highlighter(group, highlights)

--- a/lua/solarized/solarized-low/highlights.lua
+++ b/lua/solarized/solarized-low/highlights.lua
@@ -428,7 +428,7 @@ function M.load_syntax(colors)
 	syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
 	syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
 	syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
-	syntax['NavicText'] = syntax['Comment']
+	syntax['NavicText'] = syntax['LineNr']
 	syntax['NavicSeparator'] = syntax['Comment']
 
 

--- a/lua/solarized/solarized-low/highlights.lua
+++ b/lua/solarized/solarized-low/highlights.lua
@@ -401,6 +401,36 @@ function M.load_syntax(colors)
 	syntax['CmpItemKindOperator' ] = {fg=colors.base0, bg=colors.none }
 	syntax['CmpItemKindSnippet' ] = {fg=colors.orange, bg=colors.none }
 
+  syntax['NavicIconsFile'] = syntax['CmpItemKindFile']
+  syntax['NavicIconsModule'] = syntax['CmpItemKindModule']
+  syntax['NavicIconsNamespace'] = syntax['CmpItemKindModule']
+  syntax['NavicIconsPackage'] = syntax['CmpItemKindModule']
+  syntax['NavicIconsClass'] = syntax['CmpItemKindClass']
+  syntax['NavicIconsMethod'] = syntax['CmpItemKindMethod']
+  syntax['NavicIconsProperty'] = syntax['CmpItemKindProperty']
+  syntax['NavicIconsField'] = syntax['CmpItemKindField']
+  syntax['NavicIconsConstructor'] = syntax['CmpItemKindConstructor']
+  syntax['NavicIconsEnum'] = syntax['CmpItemKindEnum']
+  syntax['NavicIconsInterface'] = syntax['CmpItemKindInterface'
+  syntax['NavicIconsFunction'] = syntax['CmpItemKindFunction'
+  syntax['NavicIconsVariable'] = syntax ['CmpItemKindVariable']
+  syntax['NavicIconsConstant'] = syntax['CmpItemKindConstant']
+  syntax['NavicIconsString'] = syntax['String']
+  syntax['NavicIconsNumber'] = syntax['Number']
+  syntax['NavicIconsBoolean'] = syntax['Boolean']
+  syntax['NavicIconsArray'] = syntax['CmpItemKindClass']
+  syntax['NavicIconsObject'] = syntax['CmpItemKindClass']
+  syntax['NavicIconsKey'] = syntax['CmpItemKindKeyword']
+  syntax['NavicIconsKeyword'] = syntax['CmpItemKindKeyword']
+  syntax['NavicIconsNull'] =  {fg=colors.blue, bg=colors.none }
+  syntax['NavicIconsEnumMember'] = syntax['CmpItemKindEnumMember']
+  syntax['NavicIconsStruct'] = syntax['CmpItemKindStruct']
+  syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
+  syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
+  syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
+  syntax['NavicText'] = { fg = colors.gray, bg = colors.none}
+  syntax['NavicSeparator'] = {fg=colors.base1,style=utils.italics()}
+
 	for group, highlights in pairs(syntax) do
 		utils.highlighter(group, highlights)
 	end

--- a/lua/solarized/solarized-low/highlights.lua
+++ b/lua/solarized/solarized-low/highlights.lua
@@ -428,8 +428,9 @@ function M.load_syntax(colors)
 	syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
 	syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
 	syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
-	syntax['NavicText'] = { fg = colors.gray, bg = colors.none}
-	syntax['NavicSeparator'] = {fg=colors.base1,style=utils.italics()}
+	syntax['NavicText'] = syntax['Comment']
+	syntax['NavicSeparator'] = syntax['Comment']
+
 
 	for group, highlights in pairs(syntax) do
 		utils.highlighter(group, highlights)

--- a/lua/solarized/solarized-low/highlights.lua
+++ b/lua/solarized/solarized-low/highlights.lua
@@ -401,35 +401,35 @@ function M.load_syntax(colors)
 	syntax['CmpItemKindOperator' ] = {fg=colors.base0, bg=colors.none }
 	syntax['CmpItemKindSnippet' ] = {fg=colors.orange, bg=colors.none }
 
-  syntax['NavicIconsFile'] = syntax['CmpItemKindFile']
-  syntax['NavicIconsModule'] = syntax['CmpItemKindModule']
-  syntax['NavicIconsNamespace'] = syntax['CmpItemKindModule']
-  syntax['NavicIconsPackage'] = syntax['CmpItemKindModule']
-  syntax['NavicIconsClass'] = syntax['CmpItemKindClass']
-  syntax['NavicIconsMethod'] = syntax['CmpItemKindMethod']
-  syntax['NavicIconsProperty'] = syntax['CmpItemKindProperty']
-  syntax['NavicIconsField'] = syntax['CmpItemKindField']
-  syntax['NavicIconsConstructor'] = syntax['CmpItemKindConstructor']
-  syntax['NavicIconsEnum'] = syntax['CmpItemKindEnum']
-  syntax['NavicIconsInterface'] = syntax['CmpItemKindInterface'
-  syntax['NavicIconsFunction'] = syntax['CmpItemKindFunction'
-  syntax['NavicIconsVariable'] = syntax ['CmpItemKindVariable']
-  syntax['NavicIconsConstant'] = syntax['CmpItemKindConstant']
-  syntax['NavicIconsString'] = syntax['String']
-  syntax['NavicIconsNumber'] = syntax['Number']
-  syntax['NavicIconsBoolean'] = syntax['Boolean']
-  syntax['NavicIconsArray'] = syntax['CmpItemKindClass']
-  syntax['NavicIconsObject'] = syntax['CmpItemKindClass']
-  syntax['NavicIconsKey'] = syntax['CmpItemKindKeyword']
-  syntax['NavicIconsKeyword'] = syntax['CmpItemKindKeyword']
-  syntax['NavicIconsNull'] =  {fg=colors.blue, bg=colors.none }
-  syntax['NavicIconsEnumMember'] = syntax['CmpItemKindEnumMember']
-  syntax['NavicIconsStruct'] = syntax['CmpItemKindStruct']
-  syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
-  syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
-  syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
-  syntax['NavicText'] = { fg = colors.gray, bg = colors.none}
-  syntax['NavicSeparator'] = {fg=colors.base1,style=utils.italics()}
+	syntax['NavicIconsFile'] = syntax['CmpItemKindFile']
+	syntax['NavicIconsModule'] = syntax['CmpItemKindModule']
+	syntax['NavicIconsNamespace'] = syntax['CmpItemKindModule']
+	syntax['NavicIconsPackage'] = syntax['CmpItemKindModule']
+	syntax['NavicIconsClass'] = syntax['CmpItemKindClass']
+	syntax['NavicIconsMethod'] = syntax['CmpItemKindMethod']
+	syntax['NavicIconsProperty'] = syntax['CmpItemKindProperty']
+	syntax['NavicIconsField'] = syntax['CmpItemKindField']
+	syntax['NavicIconsConstructor'] = syntax['CmpItemKindConstructor']
+	syntax['NavicIconsEnum'] = syntax['CmpItemKindEnum']
+	syntax['NavicIconsInterface'] = syntax['CmpItemKindInterface']
+	syntax['NavicIconsFunction'] = syntax['CmpItemKindFunction']
+	syntax['NavicIconsVariable'] = syntax ['CmpItemKindVariable']
+	syntax['NavicIconsConstant'] = syntax['CmpItemKindConstant']
+	syntax['NavicIconsString'] = syntax['String']
+	syntax['NavicIconsNumber'] = syntax['Number']
+	syntax['NavicIconsBoolean'] = syntax['Boolean']
+	syntax['NavicIconsArray'] = syntax['CmpItemKindClass']
+	syntax['NavicIconsObject'] = syntax['CmpItemKindClass']
+	syntax['NavicIconsKey'] = syntax['CmpItemKindKeyword']
+	syntax['NavicIconsKeyword'] = syntax['CmpItemKindKeyword']
+	syntax['NavicIconsNull'] =  {fg=colors.blue, bg=colors.none }
+	syntax['NavicIconsEnumMember'] = syntax['CmpItemKindEnumMember']
+	syntax['NavicIconsStruct'] = syntax['CmpItemKindStruct']
+	syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
+	syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
+	syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
+	syntax['NavicText'] = { fg = colors.gray, bg = colors.none}
+	syntax['NavicSeparator'] = {fg=colors.base1,style=utils.italics()}
 
 	for group, highlights in pairs(syntax) do
 		utils.highlighter(group, highlights)

--- a/lua/solarized/solarized-normal/highlights.lua
+++ b/lua/solarized/solarized-normal/highlights.lua
@@ -473,7 +473,7 @@ function M.load_syntax(colors)
 	syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
 	syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
 	syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
-	syntax['NavicText'] = syntax['Comment']
+	syntax['NavicText'] = syntax['LineNr']
 	syntax['NavicSeparator'] = syntax['Comment']
 
 	for group, highlights in pairs(syntax) do

--- a/lua/solarized/solarized-normal/highlights.lua
+++ b/lua/solarized/solarized-normal/highlights.lua
@@ -473,8 +473,8 @@ function M.load_syntax(colors)
 	syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
 	syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
 	syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
-	syntax['NavicText'] = { fg = colors.gray, bg = colors.none}
-	syntax['NavicSeparator'] = {fg=colors.base01,style=utils.italics()}
+	syntax['NavicText'] = syntax['Comment']
+	syntax['NavicSeparator'] = syntax['Comment']
 
 	for group, highlights in pairs(syntax) do
 		utils.highlighter(group, highlights)

--- a/lua/solarized/solarized-normal/highlights.lua
+++ b/lua/solarized/solarized-normal/highlights.lua
@@ -446,35 +446,35 @@ function M.load_syntax(colors)
 	syntax['CmpItemKindOperator' ] = {fg=colors.base1, bg=colors.none }
 	syntax['CmpItemKindSnippet' ] = {fg=colors.orange, bg=colors.none }
 
-  syntax['NavicIconsFile'] = syntax['CmpItemKindFile']
-  syntax['NavicIconsModule'] = syntax['CmpItemKindModule']
-  syntax['NavicIconsNamespace'] = syntax['CmpItemKindModule']
-  syntax['NavicIconsPackage'] = syntax['CmpItemKindModule']
-  syntax['NavicIconsClass'] = syntax['CmpItemKindClass']
-  syntax['NavicIconsMethod'] = syntax['CmpItemKindMethod']
-  syntax['NavicIconsProperty'] = syntax['CmpItemKindProperty']
-  syntax['NavicIconsField'] = syntax['CmpItemKindField']
-  syntax['NavicIconsConstructor'] = syntax['CmpItemKindConstructor']
-  syntax['NavicIconsEnum'] = syntax['CmpItemKindEnum']
-  syntax['NavicIconsInterface'] = syntax['CmpItemKindInterface'
-  syntax['NavicIconsFunction'] = syntax['CmpItemKindFunction'
-  syntax['NavicIconsVariable'] = syntax ['CmpItemKindVariable']
-  syntax['NavicIconsConstant'] = syntax['CmpItemKindConstant']
-  syntax['NavicIconsString'] = syntax['String']
-  syntax['NavicIconsNumber'] = syntax['Number']
-  syntax['NavicIconsBoolean'] = syntax['Boolean']
-  syntax['NavicIconsArray'] = syntax['CmpItemKindClass']
-  syntax['NavicIconsObject'] = syntax['CmpItemKindClass']
-  syntax['NavicIconsKey'] = syntax['CmpItemKindKeyword']
-  syntax['NavicIconsKeyword'] = syntax['CmpItemKindKeyword']
-  syntax['NavicIconsNull'] =  {fg=colors.blue, bg=colors.none }
-  syntax['NavicIconsEnumMember'] = syntax['CmpItemKindEnumMember']
-  syntax['NavicIconsStruct'] = syntax['CmpItemKindStruct']
-  syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
-  syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
-  syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
-  syntax['NavicText'] = { fg = colors.gray, bg = colors.none}
-  syntax['NavicSeparator'] = {fg=colors.base01,style=utils.italics()}
+	syntax['NavicIconsFile'] = syntax['CmpItemKindFile']
+	syntax['NavicIconsModule'] = syntax['CmpItemKindModule']
+	syntax['NavicIconsNamespace'] = syntax['CmpItemKindModule']
+	syntax['NavicIconsPackage'] = syntax['CmpItemKindModule']
+	syntax['NavicIconsClass'] = syntax['CmpItemKindClass']
+	syntax['NavicIconsMethod'] = syntax['CmpItemKindMethod']
+	syntax['NavicIconsProperty'] = syntax['CmpItemKindProperty']
+	syntax['NavicIconsField'] = syntax['CmpItemKindField']
+	syntax['NavicIconsConstructor'] = syntax['CmpItemKindConstructor']
+	syntax['NavicIconsEnum'] = syntax['CmpItemKindEnum']
+	syntax['NavicIconsInterface'] = syntax['CmpItemKindInterface']
+	syntax['NavicIconsFunction'] = syntax['CmpItemKindFunction']
+	syntax['NavicIconsVariable'] = syntax ['CmpItemKindVariable']
+	syntax['NavicIconsConstant'] = syntax['CmpItemKindConstant']
+	syntax['NavicIconsString'] = syntax['String']
+	syntax['NavicIconsNumber'] = syntax['Number']
+	syntax['NavicIconsBoolean'] = syntax['Boolean']
+	syntax['NavicIconsArray'] = syntax['CmpItemKindClass']
+	syntax['NavicIconsObject'] = syntax['CmpItemKindClass']
+	syntax['NavicIconsKey'] = syntax['CmpItemKindKeyword']
+	syntax['NavicIconsKeyword'] = syntax['CmpItemKindKeyword']
+	syntax['NavicIconsNull'] =  {fg=colors.blue, bg=colors.none }
+	syntax['NavicIconsEnumMember'] = syntax['CmpItemKindEnumMember']
+	syntax['NavicIconsStruct'] = syntax['CmpItemKindStruct']
+	syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
+	syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
+	syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
+	syntax['NavicText'] = { fg = colors.gray, bg = colors.none}
+	syntax['NavicSeparator'] = {fg=colors.base01,style=utils.italics()}
 
 	for group, highlights in pairs(syntax) do
 		utils.highlighter(group, highlights)

--- a/lua/solarized/solarized-normal/highlights.lua
+++ b/lua/solarized/solarized-normal/highlights.lua
@@ -446,6 +446,36 @@ function M.load_syntax(colors)
 	syntax['CmpItemKindOperator' ] = {fg=colors.base1, bg=colors.none }
 	syntax['CmpItemKindSnippet' ] = {fg=colors.orange, bg=colors.none }
 
+  syntax['NavicIconsFile'] = syntax['CmpItemKindFile']
+  syntax['NavicIconsModule'] = syntax['CmpItemKindModule']
+  syntax['NavicIconsNamespace'] = syntax['CmpItemKindModule']
+  syntax['NavicIconsPackage'] = syntax['CmpItemKindModule']
+  syntax['NavicIconsClass'] = syntax['CmpItemKindClass']
+  syntax['NavicIconsMethod'] = syntax['CmpItemKindMethod']
+  syntax['NavicIconsProperty'] = syntax['CmpItemKindProperty']
+  syntax['NavicIconsField'] = syntax['CmpItemKindField']
+  syntax['NavicIconsConstructor'] = syntax['CmpItemKindConstructor']
+  syntax['NavicIconsEnum'] = syntax['CmpItemKindEnum']
+  syntax['NavicIconsInterface'] = syntax['CmpItemKindInterface'
+  syntax['NavicIconsFunction'] = syntax['CmpItemKindFunction'
+  syntax['NavicIconsVariable'] = syntax ['CmpItemKindVariable']
+  syntax['NavicIconsConstant'] = syntax['CmpItemKindConstant']
+  syntax['NavicIconsString'] = syntax['String']
+  syntax['NavicIconsNumber'] = syntax['Number']
+  syntax['NavicIconsBoolean'] = syntax['Boolean']
+  syntax['NavicIconsArray'] = syntax['CmpItemKindClass']
+  syntax['NavicIconsObject'] = syntax['CmpItemKindClass']
+  syntax['NavicIconsKey'] = syntax['CmpItemKindKeyword']
+  syntax['NavicIconsKeyword'] = syntax['CmpItemKindKeyword']
+  syntax['NavicIconsNull'] =  {fg=colors.blue, bg=colors.none }
+  syntax['NavicIconsEnumMember'] = syntax['CmpItemKindEnumMember']
+  syntax['NavicIconsStruct'] = syntax['CmpItemKindStruct']
+  syntax['NavicIconsEvent'] = syntax['CmpItemKindEvent']
+  syntax['NavicIconsOperator'] = syntax['CmpItemKindOperator']
+  syntax['NavicIconsTypeParameter'] = syntax['CmpItemKindTypeParameter']
+  syntax['NavicText'] = { fg = colors.gray, bg = colors.none}
+  syntax['NavicSeparator'] = {fg=colors.base01,style=utils.italics()}
+
 	for group, highlights in pairs(syntax) do
 		utils.highlighter(group, highlights)
 	end


### PR DESCRIPTION
resolves https://github.com/ishan9299/nvim-solarized-lua/issues/50

<img width="570" alt="image" src="https://user-images.githubusercontent.com/1374633/191326379-6dcdb3e1-ce58-4edf-a2c1-ac67a98eefdd.png">


and without this change:
```
Invalid highlight name: NavicText
stack traceback:
        [C]: in function 'nvim_get_hl_by_name'
```
